### PR TITLE
Fix: Correctly import root README.md for VSDM2 docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ plugins:
             # The format is: "source_path_in_repo -> destination_in_docs_folder"
             docs/*, # Imports all files from the docs directory
             images/*, # Imports all files from the images directory
-            README.md -> index.md # Imports README.md and renames it to index.md in the site
+            /README.md -> index.md # Imports root README.md and renames it to index.md in the site
             ]
         # Import documentation from ZETA
         - name: "zeta"


### PR DESCRIPTION
Updated the `imports` path for `spec-VSDM2` in `mkdocs.yml` to use a leading slash for the root `README.md`.

This ensures the mkdocs-multirepo-plugin correctly identifies and imports `spec-VSDM2/README.md` to be renamed as `index.md` within the `spec-VSDM2` site directory, resolving the 404 error for the main VSDM2 documentation page.